### PR TITLE
typos fixed for the Erasure coding math foundations artile

### DIFF
--- a/content/Understanding-Erasure-Coding-Math.md
+++ b/content/Understanding-Erasure-Coding-Math.md
@@ -697,8 +697,10 @@ $$
 
 We recover 
 
-$$\begin{bmatrix}2\\
-2\end{bmatrix}$$ 
+$$
+\begin{bmatrix}2\\
+2\end{bmatrix}
+$$ 
 
 exactly—our original data vector.
 


### PR DESCRIPTION
Fixed the LaTeX typo for the article.